### PR TITLE
Avoid using Ember prototype extensions to work with more apps

### DIFF
--- a/addon/initializers/pendo.js
+++ b/addon/initializers/pendo.js
@@ -3,7 +3,9 @@ import Ember from 'ember';
 export function initialize() {
     Ember.Router.reopen({
         pendoPageLoad: Ember.on('didTransition', function () {
-            window.pendo.pageLoad();
+            if (window.pendo !== undefined) {
+              window.pendo.pageLoad();
+            }
         })
     });
 }

--- a/addon/initializers/pendo.js
+++ b/addon/initializers/pendo.js
@@ -2,8 +2,8 @@ import Ember from 'ember';
 
 export function initialize() {
     Ember.Router.reopen({
-        pendoPageLoad: function () {
+        pendoPageLoad: Ember.on('didTransition', function () {
             window.pendo.pageLoad();
-        }.on('didTransition')
+        })
     });
 }


### PR DESCRIPTION
Basically does what the title says: in an app I'm working on, functions don't have `.on` so the initializer was failing. This should ensure it works consistently for all apps!